### PR TITLE
Fix - validate reference arguments on generic method call

### DIFF
--- a/src/eQuantic.Core.Api.Client/eQuantic.Core.Api.Client.csproj
+++ b/src/eQuantic.Core.Api.Client/eQuantic.Core.Api.Client.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Api.Client</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Api.Client</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Api.Client</PackageId>

--- a/src/eQuantic.Core.Api.Crud.Client/eQuantic.Core.Api.Crud.Client.csproj
+++ b/src/eQuantic.Core.Api.Crud.Client/eQuantic.Core.Api.Crud.Client.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Api.Crud.Client</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Api.Crud.Client</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Api.Crud.Client</PackageId>

--- a/src/eQuantic.Core.Api.Crud/eQuantic.Core.Api.Crud.csproj
+++ b/src/eQuantic.Core.Api.Crud/eQuantic.Core.Api.Crud.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Api.Crud</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Api.Crud</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         
         <PackageId>eQuantic.Core.Api.Crud</PackageId>

--- a/src/eQuantic.Core.Api.Error/eQuantic.Core.Api.Error.csproj
+++ b/src/eQuantic.Core.Api.Error/eQuantic.Core.Api.Error.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Api.Error</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Api.Error</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Api.Error</PackageId>

--- a/src/eQuantic.Core.Api/Extensions/RouteHandlerBuilderExtensions.cs
+++ b/src/eQuantic.Core.Api/Extensions/RouteHandlerBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using eQuantic.Core.Application.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 

--- a/src/eQuantic.Core.Api/eQuantic.Core.Api.csproj
+++ b/src/eQuantic.Core.Api/eQuantic.Core.Api.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Api</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Api</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Api</PackageId>

--- a/src/eQuantic.Core.Application.Crud/Services/CrudServiceBase.cs
+++ b/src/eQuantic.Core.Application.Crud/Services/CrudServiceBase.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using eQuantic.Core.Application.Crud.Enums;
 using eQuantic.Core.Application.Crud.Options;
 using eQuantic.Core.Application.Entities.Data;
+using eQuantic.Core.Application.Extensions;
 using eQuantic.Core.Data.Repository;
 using eQuantic.Core.Domain.Entities.Requests;
 using eQuantic.Core.Exceptions;
@@ -201,9 +202,7 @@ public abstract class CrudServiceBase<TEntity, TRequest, TDataEntity, TUser, TKe
             return;
         
         typeof(CrudServiceBase<TEntity, TRequest, TDataEntity, TUser, TKey, TUserKey>)
-            .GetMethod(nameof(ValidateReference), BindingFlags.NonPublic | BindingFlags.Static)?
-            .MakeGenericMethod(referenceType)
-            .Invoke(null, [request]);
+            .InvokePrivateStaticMethod(nameof(ValidateReference), referenceType, [request]);
     }
 
     private static void ValidateReference<TReferenceKey>(BasicRequest request)

--- a/src/eQuantic.Core.Application.Crud/Services/CrudServiceBase.cs
+++ b/src/eQuantic.Core.Application.Crud/Services/CrudServiceBase.cs
@@ -203,7 +203,7 @@ public abstract class CrudServiceBase<TEntity, TRequest, TDataEntity, TUser, TKe
         typeof(CrudServiceBase<TEntity, TRequest, TDataEntity, TUser, TKey, TUserKey>)
             .GetMethod(nameof(ValidateReference), BindingFlags.NonPublic | BindingFlags.Static)?
             .MakeGenericMethod(referenceType)
-            .Invoke(null, [request, dataEntity]);
+            .Invoke(null, [request]);
     }
 
     private static void ValidateReference<TReferenceKey>(BasicRequest request)

--- a/src/eQuantic.Core.Application.Crud/eQuantic.Core.Application.Crud.csproj
+++ b/src/eQuantic.Core.Application.Crud/eQuantic.Core.Application.Crud.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Application.Crud</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Application.Crud</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
         
         <PackageId>eQuantic.Core.Application.Crud</PackageId>

--- a/src/eQuantic.Core.Application/Extensions/TypeExtensions.cs
+++ b/src/eQuantic.Core.Application/Extensions/TypeExtensions.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-namespace eQuantic.Core.Api.Extensions;
+namespace eQuantic.Core.Application.Extensions;
 
 public static class TypeExtensions
 {

--- a/src/eQuantic.Core.Application/eQuantic.Core.Application.csproj
+++ b/src/eQuantic.Core.Application/eQuantic.Core.Application.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Application</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Application</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
         
         <PackageId>eQuantic.Core.Application</PackageId>

--- a/src/eQuantic.Core.Domain/eQuantic.Core.Domain.csproj
+++ b/src/eQuantic.Core.Domain/eQuantic.Core.Domain.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Domain</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Domain</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Domain</PackageId>

--- a/src/eQuantic.Core.Exceptions/eQuantic.Core.Exceptions.csproj
+++ b/src/eQuantic.Core.Exceptions/eQuantic.Core.Exceptions.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Exceptions</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Exceptions</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>netstandard2.1;net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Exceptions</PackageId>

--- a/src/eQuantic.Core.Persistence/eQuantic.Core.Persistence.csproj
+++ b/src/eQuantic.Core.Persistence/eQuantic.Core.Persistence.csproj
@@ -6,9 +6,9 @@
         <Authors>eQuantic Systems</Authors>
         <RootNamespace>eQuantic.Core.Persistence</RootNamespace>
         <AssemblyTitle>eQuantic.Core.Persistence</AssemblyTitle>
-        <AssemblyVersion>1.6.15.0</AssemblyVersion>
-        <FileVersion>1.6.15.0</FileVersion>
-        <Version>1.6.15.0</Version>
+        <AssemblyVersion>1.6.16.0</AssemblyVersion>
+        <FileVersion>1.6.16.0</FileVersion>
+        <Version>1.6.16.0</Version>
         <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
 
         <PackageId>eQuantic.Core.Persistence</PackageId>


### PR DESCRIPTION
The reflection call was using the wrong number of parameters, 2 instead of one.
